### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/ml_model/app/model.py
+++ b/ml_model/app/model.py
@@ -1,6 +1,9 @@
 import os
 import joblib
 import yfinance as yf
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 MODEL_DIR = "app/models"
 os.makedirs(MODEL_DIR, exist_ok=True)
@@ -44,4 +47,5 @@ def predict_trend(coin: str):
         }
 
     except Exception as e:
-        return {"error": str(e)}
+        logging.exception("Exception during prediction for coin %s", coin)
+        return {"error": "An internal error has occurred."}


### PR DESCRIPTION
Potential fix for [https://github.com/Hari-hara7/Crypto/security/code-scanning/3](https://github.com/Hari-hara7/Crypto/security/code-scanning/3)

To fix the issue, we should ensure that users of the API are not shown internal exception details. Instead, return a generic error message such as `"An internal error has occurred."` but still log the exception (optionally with stack trace) on the server for debugging purposes. This means editing the exception handler in `predict_trend` in `ml_model/app/model.py`. Specifically, replace `return {"error": str(e)}` with a statement that logs the full exception (using the standard `logging` module), and return a generic message to the user. This does not change the API's defined behavior in successful cases but prevents the leakage of sensitive details on errors.

To support this, we need to:
- Import Python's built-in `logging` module at the top of `model.py` (if not already).
- Set up basic logging (if it's safe and appropriate in this snippet) or use logging as-is if it's already configured elsewhere.
- On exception, log the full stack trace using `logging.exception`, and return a generic error message to the user.

Only changes in `ml_model/app/model.py` are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
