### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.14.0"
+    "mongoose": "^8.14.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,9 +1,23 @@
 const express = require('express');
 const { register, login } = require('../controllers/authController');
+const rateLimit = require('express-rate-limit');
+
+// Apply stricter rate limits to sensitive endpoints
+const registerLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // Limit each IP to 5 register requests per windowMs
+  message: 'Too many accounts created from this IP, please try again after 15 minutes'
+});
+
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // Limit each IP to 10 login requests per windowMs
+  message: 'Too many login attempts from this IP, please try again after 15 minutes'
+});
 
 const router = express.Router();
 
-router.post('/register', register);
-router.post('/login', login);
+router.post('/register', registerLimiter, register);
+router.post('/login', loginLimiter, login);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/Hari-hara7/Crypto/security/code-scanning/11](https://github.com/Hari-hara7/Crypto/security/code-scanning/11)

Rate limiting should be applied to the routes that perform expensive (database) operations. In this case, the `/register` endpoint is definitely sensitive, and `/login` is as well since login attempts can be brute-forced or used for credential stuffing attacks. To fix the issue, we should use a middleware like `express-rate-limit` to specifically protect these routes. This involves importing `express-rate-limit`, defining a rate limiter with reasonable thresholds (for example, allow a maximum of 5 registration attempts per IP every 15 minutes, and maybe 10 login attempts per IP every 15 minutes), and then applying the middleware to just the `/register` and `/login` routes. All the changes should be in `backend/routes/authRoutes.js`. If `express-rate-limit` is not already imported, we need to add the required import at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
